### PR TITLE
Remove @project tag from BigNumber.php

### DIFF
--- a/BigNumber.php
+++ b/BigNumber.php
@@ -10,7 +10,6 @@ use Aza\Components\Math\Exceptions\Exception;
  *
  * Based on {@link https://github.com/moontoast/math Moontoast Math Library}
  *
- * @project Anizoptera CMF
  * @package system.math
  * @author  Amal Samally <amal.samally at gmail.com>
  * @license MIT


### PR DESCRIPTION
Hi guys,

When using Doctrine packages in our project, we get this conflict with your use of the "@project" tag in BigNumber.php:

"Doctrine\\Common\\Annotations\\AnnotationException: [Semantical Error] The annotation \"@project\" in class Aza\\Components\\Math\\BigNumber was never imported. Did you maybe forget to add a \"use\" statement for this annotation?"

It works if we remove the @project tag. 

Thanks!